### PR TITLE
update: Dockerfile deps install using --production and minor changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR $DIR
 RUN mkdir -p ./data ./config ./logs ./instances
 
 # Install dependencies
-COPY package*.json ./package.json
+COPY package*.json .
 
 # Omit dev dependencies
 RUN npm install --production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,21 @@
 FROM node:20-alpine
 
-RUN mkdir /bot
+ENV DIR /bot
+WORKDIR $DIR
 
-RUN mkdir /bot/data
-RUN mkdir /bot/config
-RUN mkdir /bot/logs
-RUN mkdir /bot/instances
-
-WORKDIR /bot
+# Directories for persistent data and configuration
+RUN mkdir -p ./data ./config ./logs ./instances
 
 # Install dependencies
+COPY package*.json ./package.json
 
-ADD package.json /bot/package.json
-ADD package-lock.json /bot/package-lock.json
+# Omit dev dependencies
+RUN npm install --production
 
-RUN npm install
-
-# Add source files
-
-ADD . /bot
+# Copy source files
+COPY . .
 
 ENV NODE_ENV=production
 
-# Entry point
-
+# Application entry point
 ENTRYPOINT ["node", "run-forever"]


### PR DESCRIPTION
From #27

Changes:

* `npm install` now use the `--production` flag.
* `/data /config /logs /instances` are created with one `mkdir` command.
* Use `COPY` over `ADD` from [ADD or COPY - Best practices | Docker Docs](https://docs.docker.com/build/building/best-practices/#add-or-copy): `The ADD instruction is best for when you need to download a remote artifact as part of your build...`
* Add some comments.