### PR TITLE
Fix IV buffer length for AES-256-CTR in MySQL crypto database

### DIFF
--- a/src/data-access/mysql-json-db-crypto.js
+++ b/src/data-access/mysql-json-db-crypto.js
@@ -15,7 +15,7 @@ const EventsManager = Tools('events');
  * @returns {String} Encrypted text
  */
 function encrypt(text, algorithm, password) {
-	const iv = Buffer.from(Crypto.randomBytes(32));
+	const iv = Buffer.from(Crypto.randomBytes(16));
 	const hash = Crypto.createHash('sha256');
 	hash.update(password);
 	let cipher = Crypto.createCipheriv(algorithm, hash.digest(), iv);


### PR DESCRIPTION
Fixes invalid IV length error when encrypting database content in MySQL crypto storage.