### PR TITLE
Fix array type validation in Pokemon translation module

### DIFF
--- a/src/bot-modules/pokemon/poke-trans/translate.js
+++ b/src/bot-modules/pokemon/poke-trans/translate.js
@@ -40,7 +40,7 @@ function searchInLanguage(lang, word, keys) {
 				if (ld <= maxLd) {
 					results.push({type: keys[i], id: k, title: translationTemp, ld: ld});
 				}
-			} else if (typeof translationTemp === "object" && typeof translationTemp.length) {
+			} else if (Array.isArray(translationTemp)) {
 				for (let j = 0; j < translationTemp.length; j++) {
 					ld = Text.levenshtein(word, normalize(translationTemp[j]), maxLd);
 					if (ld <= maxLd) {


### PR DESCRIPTION
Replaces invalid typeof length check with Array.isArray to prevent runtime errors during translation lookups.