### PR TITLE
Fix error variable check in Wikipedia summary callback

### DIFF
--- a/src/bot-modules/misc/commands/wiki.js
+++ b/src/bot-modules/misc/commands/wiki.js
@@ -243,7 +243,7 @@ module.exports = {
 			getWikiSummary(lang, title, pageId, (pageInfo, err) => {
 				markDownload(this.byIdent.id, false);
 
-				if (errFindPage) {
+				if (err) {
 					return this.errorReply(this.mlt('errfind') + ": " + err.message);
 				}
 


### PR DESCRIPTION
Fixes incorrect variable check from errFindPage to err in Wikipedia summary fetch callback to handle search API errors properly.